### PR TITLE
chore: typo fix data.go

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -42,7 +42,7 @@ type Blob struct {
 	Data          []byte
 }
 
-// BlobRequestHeader contains the orignal data size of a blob and the security required
+// BlobRequestHeader contains the original data size of a blob and the security required
 type BlobRequestHeader struct {
 	// For a blob to be accepted by ZGDA, it satisfy the AdversaryThreshold of each quorum contained in SecurityParams
 	SecurityParams []*SecurityParam `json:"security_params"`


### PR DESCRIPTION
## Pull Request Title
chore: fix typo "orignal" to "original"

### Description
This pull request corrects the typo "orignal" to "original" in the affected file. The update ensures consistency and improves the professionalism of the documentation/code.

### Changes Made
- Replaced all occurrences of "orignal" with "original."

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-da-client/72)
<!-- Reviewable:end -->
